### PR TITLE
fix: checks that metadata directory exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/aind_data_upload_utils/check_directories_job.py
+++ b/src/aind_data_upload_utils/check_directories_job.py
@@ -90,6 +90,8 @@ class CheckDirectoriesJob:
         directories_to_check = []
         # First, check all the json files in the metadata dir
         if dirs_to_check_configs.metadata_dir is not None:
+            logging.debug(f"Checking {dirs_to_check_configs.metadata_dir}")
+            self._check_path(dirs_to_check_configs.metadata_dir)
             metadata_dir_path = str(dirs_to_check_configs.metadata_dir).rstrip(
                 "/"
             )


### PR DESCRIPTION
Closes #36 

- Adds a check that a metadata directory exists to prevent false positives
- Removes setuptools-scm from build, which was causing some issues