### PR TITLE
Standardized logging 

### DIFF
--- a/log_config_template.yaml
+++ b/log_config_template.yaml
@@ -1,0 +1,61 @@
+---
+version: 1
+disable_existing_loggers: false
+formatters:
+  default:
+    "()": aind_data_upload_utils.CustomJsonFormatter
+    format: "%(asctime)s %(levelname)s %(module)s %(lineno)s %(message)s"
+    reserved_attrs:
+      - args
+      - asctime
+      - created
+      - exc_info
+      - exc_text
+      - filename
+      - funcName
+      - levelname
+      - levelno
+      - lineno
+      - message
+      - module
+      - msecs
+      - msg
+      - name
+      - pathname
+      - process
+      - processName
+      - relativeCreated
+      - stack_info
+      - taskName
+      - thread
+      - threadName
+      - color_message
+    rename_fields:
+      "asctime": "timestamp"
+      "levelname": "level"
+    static_fields:
+      "environment": "local"
+      "software_version": ext://aind_data_upload_utils.__version__
+      "software_name": "aind-data-upload-utils"
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: default
+    level: INFO
+    stream: ext://sys.stdout
+loggers:
+  '':
+    handlers:
+    - console
+    level: INFO
+    propagate: true
+  uvicorn.error:
+    handlers:
+      - console
+    level: INFO
+    propagate: false
+  uvicorn.access:
+    handlers:
+      - console
+    level: INFO
+    propagate: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
     'pydantic>2.9',
     'pydantic-settings>=2.8',
     'boto3',
-    'requests'
+    'requests',
+    'python-json-logger',
+    'PyYAML'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_data_upload_utils/__init__.py
+++ b/src/aind_data_upload_utils/__init__.py
@@ -1,3 +1,41 @@
 """Init package"""
 
+import logging.config
+import os
+from datetime import datetime, timezone
+from logging import LogRecord
+
+import yaml
+from pythonjsonlogger import json as log_json
 __version__ = "0.18.2"
+
+# We want to standardize the timestamp format to UTC and ISO-8601, which
+# requires a custom formatter and can't be done through configuration only.
+class CustomJsonFormatter(log_json.JsonFormatter):
+    """Custom class to format log timestamps as ISO-8601 UTC"""
+
+    def formatTime(self, record: LogRecord, datefmt=None) -> str:
+        """
+        Format timestamp as ISO-8601 UTC
+
+        Parameters
+        ----------
+        record : LogRecord
+        datefmt : str, optional
+          Default is None. Unused parameter, kept for signature compatibility.
+
+        Returns
+        -------
+        str
+
+        """
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+if os.path.isfile(os.getenv("LOGGING_CONFIG_FILE", "log_config.yaml")):
+    config_path = os.getenv("LOGGING_CONFIG_FILE", "log_config.yaml")
+    with open(config_path, "rt") as f:
+        config = yaml.safe_load(f.read())
+    logging.config.dictConfig(config)
+    logging.info(f"Found logging file at: {config_path}")

--- a/src/aind_data_upload_utils/__init__.py
+++ b/src/aind_data_upload_utils/__init__.py
@@ -7,7 +7,9 @@ from logging import LogRecord
 
 import yaml
 from pythonjsonlogger import json as log_json
+
 __version__ = "0.18.2"
+
 
 # We want to standardize the timestamp format to UTC and ISO-8601, which
 # requires a custom formatter and can't be done through configuration only.

--- a/src/aind_data_upload_utils/check_directories_job.py
+++ b/src/aind_data_upload_utils/check_directories_job.py
@@ -17,8 +17,6 @@ from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
 
 
-
-
 class DirectoriesToCheckConfigs(BaseModel):
     """Basic model needed from BasicUploadConfigs"""
 
@@ -204,12 +202,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/check_directories_job.py
+++ b/src/aind_data_upload_utils/check_directories_job.py
@@ -16,9 +16,7 @@ from dask import bag as dask_bag
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings
 
-# Set log level from env var
-LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class DirectoriesToCheckConfigs(BaseModel):

--- a/src/aind_data_upload_utils/check_metadata_job.py
+++ b/src/aind_data_upload_utils/check_metadata_job.py
@@ -4,16 +4,12 @@ Module to check that certain metadata files exist and are in valid format.
 
 import argparse
 import json
-import logging
-import os
 import sys
 from pathlib import Path
 from typing import Set, Tuple, Union
 
 from pydantic import Field
 from pydantic_settings import BaseSettings
-
-
 
 
 class JobSettings(BaseSettings):
@@ -115,12 +111,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/check_metadata_job.py
+++ b/src/aind_data_upload_utils/check_metadata_job.py
@@ -13,9 +13,7 @@ from typing import Set, Tuple, Union
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
-# Set log level from env var
-LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class JobSettings(BaseSettings):

--- a/src/aind_data_upload_utils/copy_metadata_files.py
+++ b/src/aind_data_upload_utils/copy_metadata_files.py
@@ -13,9 +13,6 @@ from typing import Set, Union
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
-# Set log level from env var
-LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
-logging.basicConfig(level=LOG_LEVEL)
 
 
 class JobSettings(BaseSettings):

--- a/src/aind_data_upload_utils/copy_metadata_files.py
+++ b/src/aind_data_upload_utils/copy_metadata_files.py
@@ -4,7 +4,6 @@ Small job to copy metadata files from one folder to another.
 
 import argparse
 import logging
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -12,7 +11,6 @@ from typing import Set, Union
 
 from pydantic import Field
 from pydantic_settings import BaseSettings
-
 
 
 class JobSettings(BaseSettings):
@@ -78,12 +76,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/create_s5_commands_job.py
+++ b/src/aind_data_upload_utils/create_s5_commands_job.py
@@ -18,9 +18,7 @@ from typing import List, Optional
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
-# Set log level from env var
-LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class JobSettings(BaseSettings):

--- a/src/aind_data_upload_utils/create_s5_commands_job.py
+++ b/src/aind_data_upload_utils/create_s5_commands_job.py
@@ -19,8 +19,6 @@ from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 
-
-
 class JobSettings(BaseSettings):
     """Job settings for CreateS5CommandsJob"""
 
@@ -219,12 +217,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/create_sym_links_job.py
+++ b/src/aind_data_upload_utils/create_sym_links_job.py
@@ -9,8 +9,7 @@ from typing import List, Optional
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class JobSettings(

--- a/src/aind_data_upload_utils/create_sym_links_job.py
+++ b/src/aind_data_upload_utils/create_sym_links_job.py
@@ -10,8 +10,6 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
-
-
 class JobSettings(
     BaseSettings, cli_parse_args=True, cli_ignore_unknown_args=True
 ):

--- a/src/aind_data_upload_utils/delete_folders_job.py
+++ b/src/aind_data_upload_utils/delete_folders_job.py
@@ -19,8 +19,7 @@ from aind_data_upload_utils.delete_staging_folder_job import (
     DeleteStagingFolderJob,
 )
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class JobSettings(BaseSettings):

--- a/src/aind_data_upload_utils/delete_folders_job.py
+++ b/src/aind_data_upload_utils/delete_folders_job.py
@@ -4,7 +4,6 @@ Module to handle deleting folders using dask
 
 import argparse
 import logging
-import os
 import re
 import sys
 from pathlib import Path
@@ -18,8 +17,6 @@ from pydantic_settings import BaseSettings
 from aind_data_upload_utils.delete_staging_folder_job import (
     DeleteStagingFolderJob,
 )
-
-
 
 
 class JobSettings(BaseSettings):
@@ -87,12 +84,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/delete_source_folders_job.py
+++ b/src/aind_data_upload_utils/delete_source_folders_job.py
@@ -22,8 +22,6 @@ from aind_data_upload_utils.delete_staging_folder_job import (
 )
 
 
-
-
 class DirectoriesToDeleteConfigs(BaseModel):
     """Basic model that can be easily passed via the transfer service."""
 
@@ -231,12 +229,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/delete_source_folders_job.py
+++ b/src/aind_data_upload_utils/delete_source_folders_job.py
@@ -21,8 +21,7 @@ from aind_data_upload_utils.delete_staging_folder_job import (
     DeleteStagingFolderJob,
 )
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class DirectoriesToDeleteConfigs(BaseModel):

--- a/src/aind_data_upload_utils/delete_staging_folder_job.py
+++ b/src/aind_data_upload_utils/delete_staging_folder_job.py
@@ -17,8 +17,7 @@ from pydantic import Field
 from pydantic_settings import BaseSettings
 
 # Set log level from env var
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class JobSettings(BaseSettings):

--- a/src/aind_data_upload_utils/delete_staging_folder_job.py
+++ b/src/aind_data_upload_utils/delete_staging_folder_job.py
@@ -19,7 +19,6 @@ from pydantic_settings import BaseSettings
 # Set log level from env var
 
 
-
 class JobSettings(BaseSettings):
     """Job settings for DeleteStagingFolderJob"""
 
@@ -190,12 +189,10 @@ if __name__ == "__main__":
         "--job-settings",
         required=False,
         type=str,
-        help=(
-            r"""
+        help=(r"""
             Instead of init args the job settings can optionally be passed in
             as a json string in the command line.
-            """
-        ),
+            """),
     )
     cli_args = parser.parse_args(sys_args)
     main_job_settings = JobSettings.model_validate_json(cli_args.job_settings)

--- a/src/aind_data_upload_utils/trigger_co_cleanup_notification.py
+++ b/src/aind_data_upload_utils/trigger_co_cleanup_notification.py
@@ -5,7 +5,6 @@ Job to parse CSV data and send webhook notifications.
 import argparse
 import csv
 import logging
-import os
 import sys
 from collections import defaultdict
 from io import StringIO
@@ -16,8 +15,6 @@ import boto3
 import requests
 from pydantic import Field
 from pydantic_settings import BaseSettings
-
-
 
 
 class JobSettings(BaseSettings):

--- a/src/aind_data_upload_utils/trigger_co_cleanup_notification.py
+++ b/src/aind_data_upload_utils/trigger_co_cleanup_notification.py
@@ -17,8 +17,7 @@ import requests
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
-logging.basicConfig(level=LOG_LEVEL)
+
 
 
 class JobSettings(BaseSettings):


### PR DESCRIPTION
closes #54 

adds logging template + custom log config. removes local log configs.

We could also: 
- Structured logging everywhere instead of strs (didn't include this since I wasn't sure who's using these currently, lmk if it should be included here)
- Emit a single, structured summary log at the end of each job (status, counts, errors, etc.).
